### PR TITLE
style: update code format

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -7,5 +7,6 @@
   "license": "Apache-2.0",
   "keywords": ["dom", "ffi"],
   "description": "DOM FFI (partial. used by Respo.mbt)",
-  "source": "src"
+  "source": "src",
+  "preferred-target": "js"
 }

--- a/src/lib/console.mbt
+++ b/src/lib/console.mbt
@@ -1,8 +1,11 @@
+///|
 pub extern "js" fn log(msg : String) -> Unit =
   #| (msg) => { console.log(msg) }
 
+///|
 pub extern "js" fn warn_log(msg : String) -> Unit =
   #| (msg) => { console.warn(msg) }
 
+///|
 pub extern "js" fn error_log(msg : String) -> Unit =
   #| (msg) => { console.error(msg) }

--- a/src/lib/debug.mbt
+++ b/src/lib/debug.mbt
@@ -1,2 +1,3 @@
+///|
 pub extern "js" fn debugger() -> Unit =
   #| () => { debugger }

--- a/src/lib/document.mbt
+++ b/src/lib/document.mbt
@@ -1,16 +1,19 @@
 ///|
-pub(all) extern type Document
+#external
+pub(all) type Document
 
 ///|
 pub extern "js" fn Window::document(self : Window) -> Document =
   #| (self) => self.document
 
 // body
+
 ///|
 pub extern "js" fn Document::body(self : Document) -> Element =
   #| (self) => self.body
 
 // head
+
 ///|
 pub extern "js" fn Document::head(self : Document) -> Element =
   #| (self) => self.head
@@ -18,6 +21,6 @@ pub extern "js" fn Document::head(self : Document) -> Element =
 ///|
 pub extern "js" fn Document::query_selector(
   self : Document,
-  selector : String
+  selector : String,
 ) -> Element =
   #| (self, selector) => self.querySelector(selector)

--- a/src/lib/event.mbt
+++ b/src/lib/event.mbt
@@ -1,49 +1,58 @@
 ///|
-pub extern type KeyboardEvent
+#external
+pub type KeyboardEvent
 
 ///|
 pub extern "js" fn KeyboardEvent::new_with_init_dict(
   type_ : String,
-  event_init_dict : KeyboardEventInit
+  event_init_dict : KeyboardEventInit,
 ) -> KeyboardEvent =
   #| (type_, event_init_dict) => new KeyboardEvent(type_, event_init_dict)
 
 // key
+
 ///|
 pub extern "js" fn key(self : KeyboardEvent) -> String =
   #| (self) => self.key
 
 // type_
+
 ///|
 pub extern "js" fn type_(self : KeyboardEvent) -> String =
   #| (self) => self.type
 
 // key_code
+
 ///|
 pub extern "js" fn key_code(self : KeyboardEvent) -> UInt =
   #| (self) => self.keyCode
 
 // shift_key
+
 ///|
 pub extern "js" fn shift_key(self : KeyboardEvent) -> Bool =
   #| (self) => self.shiftKey
 
 // ctrl_key
+
 ///|
 pub extern "js" fn ctrl_key(self : KeyboardEvent) -> Bool =
   #| (self) => self.ctrlKey
 
 // alt_key
+
 ///|
 pub extern "js" fn alt_key(self : KeyboardEvent) -> Bool =
   #| (self) => self.altKey
 
 // meta_key
+
 ///|
 pub extern "js" fn meta_key(self : KeyboardEvent) -> Bool =
   #| (self) => self.metaKey
 
 // repeat
+
 ///|
 pub extern "js" fn repeat(self : KeyboardEvent) -> Bool =
   #| (self) => self.repeat
@@ -65,6 +74,7 @@ pub extern "js" fn location(self : KeyboardEvent) -> UInt =
   #| (self) => self.location
 
 // dispatch_event
+
 ///|
 pub extern "js" fn dispatch_event(self : Node, event : KeyboardEvent) -> Bool =
   #| (self, event) => self.dispatchEvent(event)
@@ -78,12 +88,14 @@ pub extern "js" fn stop_propagation(self : KeyboardEvent) -> Unit =
   #| (self) => self.stopPropagation()
 
 // set_repeat
+
 ///|
 pub extern "js" fn set_repeat(self : KeyboardEvent, repeat : Bool) -> Unit =
   #| (self, repeat) => { self.repeat = repeat }
 
 ///| need to init function first before creating real event
-pub extern type KeyboardEventInit
+#external
+pub type KeyboardEventInit
 
 ///|
 pub extern "js" fn KeyboardEventInit::new() -> KeyboardEventInit =
@@ -92,7 +104,7 @@ pub extern "js" fn KeyboardEventInit::new() -> KeyboardEventInit =
 ///|
 pub extern "js" fn keyboard_event_init(
   self : Window,
-  type_ : String
+  type_ : String,
 ) -> KeyboardEventInit =
   #| (self, type) => ({})
 
@@ -107,7 +119,7 @@ pub extern "js" fn set_code(self : KeyboardEventInit, code : String) -> Unit =
 ///|
 pub extern "js" fn set_char_code(
   self : KeyboardEventInit,
-  char_code : UInt
+  char_code : UInt,
 ) -> Unit =
   #| (self, char_code) => { self.charCode = char_code }
 
@@ -118,28 +130,32 @@ pub extern "js" fn set_view(self : KeyboardEventInit, view : Window) -> Unit =
 ///|
 pub extern "js" fn set_location(
   self : KeyboardEventInit,
-  location : UInt
+  location : UInt,
 ) -> Unit =
   #| (self, location) => { self.location = location }
 
 ///|
 pub extern "js" fn set_key_code(
   self : KeyboardEventInit,
-  key_code : UInt
+  key_code : UInt,
 ) -> Unit =
   #| (self, key_code) => { self.keyCode = key_code }
 
 ///|
-pub extern type InputEvent
+#external
+pub type InputEvent
 
 ///|
-pub extern type FocusEvent
+#external
+pub type FocusEvent
 
 ///|
-pub extern type BlurEvent
+#external
+pub type BlurEvent
 
 ///|
-pub extern type MouseEvent
+#external
+pub type MouseEvent
 
 ///|
 pub extern "js" fn MouseEvent::stop_propagation(self : MouseEvent) -> Unit =
@@ -150,11 +166,13 @@ pub extern "js" fn MouseEvent::prevent_default(self : MouseEvent) -> Unit =
   #| (self) => self.preventDefault()
 
 // client_x
+
 ///|
 pub extern "js" fn MouseEvent::client_x(self : MouseEvent) -> Float =
   #| (self) => self.clientX
 
 // client_y
+
 ///|
 pub extern "js" fn MouseEvent::client_y(self : MouseEvent) -> Float =
   #| (self) => self.clientY

--- a/src/lib/location.mbt
+++ b/src/lib/location.mbt
@@ -1,5 +1,6 @@
 ///| https://developer.mozilla.org/en-US/docs/Web/API/Location
-pub(all) extern type Location
+#external
+pub(all) type Location
 
 ///|
 pub extern "js" fn Window::location(self : Window) -> Location =

--- a/src/lib/navigator.mbt
+++ b/src/lib/navigator.mbt
@@ -1,3 +1,4 @@
 ///| `window.navigator` object
 /// https://developer.mozilla.org/en-US/docs/Web/API/Navigator
-pub(all) extern type Navigator
+#external
+pub(all) type Navigator

--- a/src/lib/node.mbt
+++ b/src/lib/node.mbt
@@ -1,12 +1,14 @@
 ///| DOM Node type
 /// <https://developer.mozilla.org/en-US/docs/Web/API/Node>
-pub(all) extern type Node
+#external
+pub(all) type Node
 
 ///|
 pub extern "js" fn Node::child_nodes(self : Node) -> Array[Node] =
   #| (self) => self.childNodes
 
 // children
+
 ///|
 pub extern "js" fn Node::children(self : Node) -> Array[Node] =
   #| (self) => self.children
@@ -16,29 +18,32 @@ pub extern "js" fn Node::reinterpret_as_element(self : Node) -> Element =
   #| (self) => self
 
 // reinterpret_as_node
+
 ///|
 pub extern "js" fn Element::reinterpret_as_node(self : Element) -> Node =
   #| (self) => self
 
 // first_child
+
 ///|
 pub extern "js" fn Node::first_child(self : Node) -> Node =
   #| (self) => self.firstChild
 
 ///|
-pub(all) extern type Element
+#external
+pub(all) type Element
 
 ///|
 pub extern "js" fn Element::set_inner_html(
   self : Element,
-  html : String
+  html : String,
 ) -> Unit =
   #| (self, html) => { self.innerHTML = html }
 
 ///|
 pub extern "js" fn Element::set_inner_text(
   self : Element,
-  text : String
+  text : String,
 ) -> Unit =
   #| (self, text) => { self.innerText = text }
 
@@ -54,15 +59,16 @@ pub extern "js" fn Element::tag_name(self : Element) -> String =
 pub extern "js" fn Element::set_attribute(
   self : Element,
   name : String,
-  value : String
+  value : String,
 ) -> Unit =
   #| (self, name, value) => { self.setAttribute(name, value) }
 
 // remove_attribute
+
 ///|
 pub extern "js" fn Element::remove_attribute(
   self : Element,
-  name : String
+  name : String,
 ) -> Unit =
   #| (self, name) => { self.removeAttribute(name) }
 
@@ -70,21 +76,21 @@ pub extern "js" fn Element::remove_attribute(
 pub extern "js" fn Element::set_data_attribute(
   self : Element,
   name : String,
-  value : String
+  value : String,
 ) -> Unit =
   #| (self, name, value) => { self.dataset[name] = value }
 
 ///|
 pub extern "js" fn Element::data_attribute(
   self : Element,
-  name : String
+  name : String,
 ) -> String =
   #| (self, name) => self.dataset[name]
 
 ///|
 pub extern "js" fn Element::remove_data_attribute(
   self : Element,
-  name : String
+  name : String,
 ) -> Unit =
   #| (self, name) => { delete self.dataset[name] }
 
@@ -93,50 +99,56 @@ pub extern "js" fn Element::append_child(self : Element, child : Node) -> Unit =
   #| (self, child) => { self.appendChild(child) }
 
 // set_onkeypress on input
+
 ///|
 pub extern "js" fn HtmlInputElement::set_onkeypress(
   self : HtmlInputElement,
-  f : ((KeyboardEvent) -> Unit)?
+  f : ((KeyboardEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.onkeypress = f }
 
 // set_onkeypress on textarea
+
 ///|
 pub extern "js" fn HtmlTextAreaElement::set_onkeypress(
   self : HtmlTextAreaElement,
-  f : ((KeyboardEvent) -> Unit)?
+  f : ((KeyboardEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.onkeypress = f }
 
 // set_onkeydown on input
+
 ///|
 pub extern "js" fn HtmlInputElement::set_onkeydown(
   self : HtmlInputElement,
-  f : ((KeyboardEvent) -> Unit)?
+  f : ((KeyboardEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.onkeydown = f }
 
 // set_onkeydown on textarea
+
 ///|
 pub extern "js" fn HtmlTextAreaElement::set_onkeydown(
   self : HtmlTextAreaElement,
-  f : ((KeyboardEvent) -> Unit)?
+  f : ((KeyboardEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.onkeydown = f }
 
 // set_onkeyup on input
+
 ///|
 pub extern "js" fn HtmlInputElement::set_onkeyup(
   self : HtmlInputElement,
-  f : ((KeyboardEvent) -> Unit)?
+  f : ((KeyboardEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.onkeyup = f }
 
 // set_onkeyup on textarea
+
 ///|
 pub extern "js" fn HtmlTextAreaElement::set_onkeyup(
   self : HtmlTextAreaElement,
-  f : ((KeyboardEvent) -> Unit)?
+  f : ((KeyboardEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) =>  { self.onkeyup = f }
 
@@ -149,84 +161,94 @@ pub extern "js" fn Node::owner_document(self : Node) -> Document =
   #| (self) => self.ownerDocument
 
 ///|
-pub(all) extern type HtmlInputElement
+#external
+pub(all) type HtmlInputElement
 
 ///|
 pub extern "js" fn Element::reinterpret_as_html_input_element(
-  self : Element
+  self : Element,
 ) -> HtmlInputElement =
   #| (self) => self
 
 ///|
-pub(all) extern type HtmlTextAreaElement
+#external
+pub(all) type HtmlTextAreaElement
 
 // set_onblur
+
 ///|
 pub extern "js" fn HtmlInputElement::set_onblur(
   self : HtmlInputElement,
-  f : ((BlurEvent) -> Unit)?
+  f : ((BlurEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.onblur = f }
 
 // set_onfocus on input
+
 ///|
 pub extern "js" fn HtmlInputElement::set_onfocus(
   self : HtmlInputElement,
-  f : ((FocusEvent) -> Unit)?
+  f : ((FocusEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.onfocus = f }
 
 // set_onblur on textarea
+
 ///|
 pub extern "js" fn HtmlTextAreaElement::set_onblur(
   self : HtmlTextAreaElement,
-  f : ((BlurEvent) -> Unit)?
+  f : ((BlurEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.onblur = f }
 
 // set_onfocus on textarea
+
 ///|
 pub extern "js" fn HtmlTextAreaElement::set_onfocus(
   self : HtmlTextAreaElement,
-  f : ((FocusEvent) -> Unit)?
+  f : ((FocusEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.onfocus = f }
 
 // set_onchange on input
+
 ///|
 pub extern "js" fn HtmlInputElement::set_onchange(
   self : HtmlInputElement,
-  f : ((InputEvent) -> Unit)?
+  f : ((InputEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.onchange = f }
 
 // set_onchange on textarea
+
 ///|
 pub extern "js" fn HtmlTextAreaElement::set_onchange(
   self : HtmlTextAreaElement,
-  f : ((InputEvent) -> Unit)?
+  f : ((InputEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.onchange = f }
 
 // set_oninput on input
+
 ///|
 pub extern "js" fn HtmlInputElement::set_oninput(
   self : HtmlInputElement,
-  f : (InputEvent) -> Unit
+  f : (InputEvent) -> Unit,
 ) -> Unit =
   #| (self, f) => { self.oninput = f }
 
 ///|
 pub extern "js" fn HtmlInputElement::unset_oninput(
-  self : HtmlInputElement
+  self : HtmlInputElement,
 ) -> Unit =
   #| (self) => { self.oninput = null }
 
 // set_oninput on textarea
+
 ///|
 pub extern "js" fn HtmlTextAreaElement::set_oninput(
   self : HtmlTextAreaElement,
-  f : ((InputEvent) -> Unit)?
+  f : ((InputEvent) -> Unit)?,
 ) -> Unit =
   #| (self, f) => { self.oninput = f }
 
@@ -237,49 +259,53 @@ pub extern "js" fn HtmlInputElement::value(self : HtmlInputElement) -> String =
 ///|
 pub extern "js" fn HtmlInputElement::set_value(
   self : HtmlInputElement,
-  value : String
+  value : String,
 ) -> Unit =
   #| (self, value) => { self.value = value }
 
 ///|
 pub extern "js" fn HtmlTextAreaElement::value(
-  self : HtmlTextAreaElement
+  self : HtmlTextAreaElement,
 ) -> String =
   #| (self) => self.value
 
 ///|
 pub extern "js" fn HtmlTextAreaElement::set_value(
   self : HtmlTextAreaElement,
-  value : String
+  value : String,
 ) -> Unit =
   #| (self, value) => { self.value = value }
 
 // parent_element
+
 ///|
 pub extern "js" fn Node::parent_element(self : Node) -> Element =
   #| (self) => self.parentElement
 
 ///|
 pub extern "js" fn Element::reinterpret_as_html_textarea_element(
-  self : Element
+  self : Element,
 ) -> HtmlTextAreaElement =
   #| (self) => self
 
 // remove
+
 ///|
 pub extern "js" fn Node::remove(self : Node) -> Unit =
   #| (self) => { self.remove() }
 
 // remove_child from Node
+
 ///|
 pub extern "js" fn Node::remove_child(self : Node, child : Node) -> Unit =
   #| (self, child) => { self.removeChild(child) }
 
 // set_onclick
+
 ///|
 pub extern "js" fn Element::set_onclick(
   self : Element,
-  f : (MouseEvent) -> Unit
+  f : (MouseEvent) -> Unit,
 ) -> Unit =
   #| (self, f) => { self.onclick = f }
 
@@ -288,10 +314,11 @@ pub extern "js" fn Element::unset_onclick(self : Element) -> Unit =
   #| (self) => { self.onclick = null }
 
 // set_ondblclick
+
 ///|
 pub extern "js" fn Element::set_ondblclick(
   self : Element,
-  f : (MouseEvent) -> Unit
+  f : (MouseEvent) -> Unit,
 ) -> Unit =
   #| (self, f) => { self.ondblclick = f }
 
@@ -302,15 +329,16 @@ pub extern "js" fn Element::unset_ondblclick(self : Element) -> Unit =
 ///|
 pub extern "js" fn Element::query_selector(
   self : Element,
-  selector : String
+  selector : String,
 ) -> Element =
   #| (self, selector) => self.querySelector(selector)
 
 // create_element
+
 ///|
 pub extern "js" fn Document::create_element(
   self : Document,
-  name : String
+  name : String,
 ) -> Element =
   #| (self, name) => self.createElement(name)
 
@@ -319,15 +347,17 @@ pub extern "js" fn Node::append_child(self : Node, child : Node) -> Unit =
   #| (self, child) => self.appendChild(child)
 
 ///| insert_before on Node
+
 ///| notice that `Option[T]` is using `._0` to get the value, which may be unstable
 pub extern "js" fn Node::insert_before(
   self : Node,
   new_child : Node,
-  reference_child : Node?
+  reference_child : Node?,
 ) -> Unit =
   #| (self, new_child, reference_child) => { self.insertBefore(new_child, reference_child?._0) }
 
 // target on input event
+
 ///|
 pub extern "js" fn InputEvent::target(self : InputEvent) -> Element =
   #| (self) => self.target

--- a/src/lib/params.mbt
+++ b/src/lib/params.mbt
@@ -1,5 +1,6 @@
 ///| https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
-extern type URLSearchParams
+#external
+type URLSearchParams
 
 ///|
 pub extern "js" fn new_url_search_params(s : String) -> URLSearchParams =
@@ -8,21 +9,21 @@ pub extern "js" fn new_url_search_params(s : String) -> URLSearchParams =
 ///|
 pub extern "js" fn URLSearchParams::has(
   self : URLSearchParams,
-  name : String
+  name : String,
 ) -> Bool =
   #| (self, name) => self.has(name)
 
 ///|
 pub extern "js" fn URLSearchParams::get(
   self : URLSearchParams,
-  name : String
+  name : String,
 ) -> String =
   #| (self, name) => self.get(name)
 
 ///|
 pub extern "js" fn URLSearchParams::get_all(
   self : URLSearchParams,
-  name : String
+  name : String,
 ) -> Array[String] =
   #| (self, name) => self.getAll(name)
 
@@ -30,7 +31,7 @@ pub extern "js" fn URLSearchParams::get_all(
 pub extern "js" fn URLSearchParams::set(
   self : URLSearchParams,
   name : String,
-  value : String
+  value : String,
 ) -> Unit =
   #| (self, name, value) => self.set(name, value)
 
@@ -38,14 +39,14 @@ pub extern "js" fn URLSearchParams::set(
 pub extern "js" fn URLSearchParams::append(
   self : URLSearchParams,
   name : String,
-  value : String
+  value : String,
 ) -> Unit =
   #| (self, name, value) => self.append(name, value)
 
 ///|
 pub extern "js" fn URLSearchParams::delete(
   self : URLSearchParams,
-  name : String
+  name : String,
 ) -> Unit =
   #| (self, name) => self.delete(name)
 

--- a/src/lib/performance.mbt
+++ b/src/lib/performance.mbt
@@ -1,12 +1,15 @@
 // performance
+
 ///|
-pub(all) extern type Performance
+#external
+pub(all) type Performance
 
 ///|
 pub extern "js" fn Window::performance(self : Window) -> Performance =
   #| (self) => self.performance
 
 // performance.now
+
 ///|
 pub extern "js" fn Performance::now(self : Performance) -> Float =
   #| (self) => self.now()

--- a/src/lib/promise.mbt
+++ b/src/lib/promise.mbt
@@ -1,7 +1,8 @@
 // TODO: Implement Promise
 
 ///|
-pub(all) extern type JsValue
+#external
+pub(all) type JsValue
 
 ///|
 pub(all) struct Promise[T] {
@@ -11,6 +12,6 @@ pub(all) struct Promise[T] {
 ///|
 pub extern "js" fn JsValue::then_ffi(
   self : JsValue,
-  f : (JsValue) -> JsValue
+  f : (JsValue) -> JsValue,
 ) -> Promise[JsValue] =
   #| (self, f) => { self.then(f) }

--- a/src/lib/respo-dirty.mbt
+++ b/src/lib/respo-dirty.mbt
@@ -1,67 +1,87 @@
-/// this file contains dirty functions that Respo requires to call js
+///| this file contains dirty functions that Respo requires to call js
 
 // window
 pub extern "js" fn load_my_window() -> Window =
   #| () => window
 
 // dirty_get_fn
+
+///|
 pub extern "js" fn dirty_get_fn(self : Window, name : String) -> () -> Unit =
   #| (self, name) => self[name]
 
 // dirty_set_fn
+
+///|
 pub extern "js" fn dirty_set_fn(self : Window, name : String, f : () -> Unit) =
   #| (self, name, f) => { self[name] = f }
 
 // dirty_call_fn
+
+///|
 pub extern "js" fn dirty_call_fn(self : Window, name : String) -> Unit =
   #| (self, name) => self[name]?.()
 
 // dirty_remove_fn
+
+///|
 pub extern "js" fn dirty_remove_fn(self : Window, name : String) -> Unit =
   #| (self, name) => delete self[name]
 
 // dirty_get_fn_1
+
+///|
 pub extern "js" fn dirty_get_fn_1(
   self : Window,
-  name : String
+  name : String,
 ) -> (String) -> Unit =
   #| (self, name) => self[name]
 
 // dirty_set_fn_1
+
+///|
 pub extern "js" fn dirty_set_fn_1(
   self : Window,
   name : String,
-  f : (String) -> Unit
+  f : (String) -> Unit,
 ) =
   #| (self, name, f) => { self[name] = f }
 
 // dirty_call_fn_1
+
+///|
 pub extern "js" fn dirty_call_fn_1(
   self : Window,
   name : String,
-  v1 : String
+  v1 : String,
 ) -> Unit =
   #| (self, name, v1) => self[name]?.(v1)
 
-/// a temporary solution for generating random id
+///| a temporary solution for generating random id
 pub extern "js" fn random_id() -> String =
   #| () => Math.random().toString(36).slice(2)
 
 // dirty_get_attribute_fn
+
+///|
 pub extern "js" fn dirty_get_attribute_fn(
   self : Element,
-  name : String
+  name : String,
 ) -> () -> Bool =
   #| (self, name) => self[name]
 
 // dirty_set_attribute_fn
+
+///|
 pub extern "js" fn dirty_set_attribute_fn(
   self : Element,
   name : String,
-  f : (KeyboardEvent) -> Bool
+  f : (KeyboardEvent) -> Bool,
 ) =
   #| (self, name, f) => self[name] = f
 
 // dirty_remove_attribute_fn
+
+///|
 pub extern "js" fn dirty_remove_attribute_fn(self : Element, name : String) =
   #| (self, name) => delete self[name]

--- a/src/lib/storage.mbt
+++ b/src/lib/storage.mbt
@@ -1,5 +1,6 @@
 ///|
-pub(all) extern type LocalStorage
+#external
+pub(all) type LocalStorage
 
 ///|
 pub extern "js" fn local_storage(self : Window) -> LocalStorage =
@@ -13,13 +14,13 @@ pub extern "js" fn get_item(self : LocalStorage, key : String) -> String? =
 pub extern "js" fn LocalStorage::set_item(
   self : LocalStorage,
   key : String,
-  value : String
+  value : String,
 ) -> Unit =
   #| (self, key, value) => { self.setItem(key, value) }
 
 ///|
 pub extern "js" fn LocalStorage::remove_item(
   self : LocalStorage,
-  key : String
+  key : String,
 ) -> Unit =
   #| (self, key) => { self.removeItem(key) }

--- a/src/lib/style.mbt
+++ b/src/lib/style.mbt
@@ -1,24 +1,28 @@
 // style
+
 ///|
-pub(all) extern type CSSStyleDeclaration
+#external
+pub(all) type CSSStyleDeclaration
 
 ///|
 pub extern "js" fn Node::style(self : Node) -> CSSStyleDeclaration =
   #| (self) => self.style
 
 // set_property
+
 ///|
 pub extern "js" fn CSSStyleDeclaration::set_property(
   self : CSSStyleDeclaration,
   name : String,
-  value : String
+  value : String,
 ) -> Unit =
   #| (self, name, value) => { self[name] = value }
 
 // remove_property
+
 ///|
 pub extern "js" fn CSSStyleDeclaration::remove_property(
   self : CSSStyleDeclaration,
-  name : String
+  name : String,
 ) -> Unit =
   #| (self, name) => { delete self[name] }

--- a/src/lib/window.mbt
+++ b/src/lib/window.mbt
@@ -1,25 +1,28 @@
 ///| window
-pub(all) extern type Window
+#external
+pub(all) type Window
 
 ///|
 pub extern "js" fn window() -> Window =
   #| () => window
 
 // add_event_listener_with_callback
+
 ///|
 pub extern "js" fn Window::add_event_listener_with_callback(
   self : Window,
   type_ : String,
-  f : (KeyboardEvent) -> Bool // TODO
+  f : (KeyboardEvent) -> Bool, // TODO
 ) -> Unit =
   #| (self, type, f) => { self.addEventListener(type, f) }
 
 // remove_event_listener_with_callback
+
 ///|
 pub extern "js" fn Window::remove_event_listener_with_callback(
   self : Window,
   type_ : String,
-  f : () -> Bool // TODO
+  f : () -> Bool, // TODO
 ) -> Unit =
   #| (self, type, f) => { self.removeEventListener(type, f) }
 
@@ -27,19 +30,20 @@ pub extern "js" fn Window::remove_event_listener_with_callback(
 pub extern "js" fn Window::set_timeout(
   self : Window,
   f : () -> Unit,
-  ms : UInt
+  ms : UInt,
 ) -> Unit =
   #| (self, f, ms) => { self.setTimeout(f, ms) }
 
 ///|
 pub extern "js" fn Window::request_animation_frame(
   self : Window,
-  f : (Float) -> Unit
+  f : (Float) -> Unit,
 ) -> Unit =
   #| (self, f) => { self.requestAnimationFrame(f) }
 
 ///|
-pub(all) extern type BeforeUnloadEvent
+#external
+pub(all) type BeforeUnloadEvent
 
 ///|
 pub extern "js" fn before_unload_event() -> BeforeUnloadEvent =
@@ -48,6 +52,6 @@ pub extern "js" fn before_unload_event() -> BeforeUnloadEvent =
 ///|
 pub extern "js" fn set_onbeforeunload(
   self : Window,
-  f : (BeforeUnloadEvent) -> Unit
+  f : (BeforeUnloadEvent) -> Unit,
 ) -> Unit =
   #| (self, f) => { self.onbeforeunload = f }

--- a/src/main/main.mbt
+++ b/src/main/main.mbt
@@ -1,3 +1,4 @@
+///|
 fn main {
   @lib.debugger()
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This commit fixes all compiler warnings that occur when trying to build this JavaScript FFI library with the default wasm-gc target. The solution includes:

- Declaring the default build target as "js";
- Reformatting the codebase.

The library now compiles cleanly when using the appropriate JavaScript target, which is required for the extern "js" FFI functions used throughout the codebase.